### PR TITLE
Display neon render with controls

### DIFF
--- a/NeonLightsTestApp/ContentView.swift
+++ b/NeonLightsTestApp/ContentView.swift
@@ -18,11 +18,13 @@ struct ContentView: View {
     }
 
     var body: some View {
-        VStack {
+        ZStack(alignment: .bottom) {
             NeonView(renderer: vm.renderer)
-              .background(.black)
-              .frame(maxWidth: .infinity, maxHeight: .infinity)  // <— important
-              .onAppear { vm.loadSVG() }
+                .background(.black)
+                .ignoresSafeArea()
+                .onAppear { vm.loadSVG() }
+
+            ControlsView(vm: vm)
         }
     }
 }


### PR DESCRIPTION
## Summary
- overlay rendering view with controls to ensure neon image shows

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_68bed9058b3083239498b6d7cc17406a