### PR TITLE
Fix blank rendering by preloading SVG and syncing drawable size

### DIFF
--- a/NeonLightsTestApp/ContentView.swift
+++ b/NeonLightsTestApp/ContentView.swift
@@ -14,7 +14,10 @@ struct ContentView: View {
     init() {
         let device = MTLCreateSystemDefaultDevice()!
         let renderer = NeonRenderer(device: device)
-        _vm = StateObject(wrappedValue: NeonViewModel(renderer: renderer))
+        let viewModel = NeonViewModel(renderer: renderer)
+        _vm = StateObject(wrappedValue: viewModel)
+        // Preload the SVG so the renderer has geometry before the view appears.
+        viewModel.loadSVG()
     }
 
     var body: some View {
@@ -22,7 +25,6 @@ struct ContentView: View {
             NeonView(renderer: vm.renderer)
               .background(.black)
               .frame(maxWidth: .infinity, maxHeight: .infinity)  // <— important
-              .onAppear { vm.loadSVG() }
         }
     }
 }

--- a/NeonLightsTestApp/ViewModels/NeonView.swift
+++ b/NeonLightsTestApp/ViewModels/NeonView.swift
@@ -29,6 +29,10 @@ public struct NeonView: UIViewRepresentable {
     }
 
     public func updateUIView(_ uiView: MTKView, context: Context) {
-        // Nothing needed — updates flow through NeonViewModel -> renderer.update(...)
+        // Keep the drawable size in sync with SwiftUI layout changes so Metal
+        // renders at the correct resolution and aspect ratio.
+        let scale = uiView.contentScaleFactor
+        uiView.drawableSize = CGSize(width: uiView.bounds.width * scale,
+                                     height: uiView.bounds.height * scale)
     }
 }


### PR DESCRIPTION
## Summary
- Preload the SVG in `ContentView` so geometry is ready before the view appears
- Update `NeonView` to keep the MTKView drawable size in sync with SwiftUI layout changes

## Testing
- `swift test` *(fails: Could not find Package.swift in this directory or any of its parent directories.)*

------
https://chatgpt.com/codex/tasks/task_e_68bedc0cb2b08323b977ba9031e4d531