### PR TITLE
Fix mesh upload callback to ensure drawing

### DIFF
--- a/NeonLightsTestApp/ViewModels/NeonViewModel.swift
+++ b/NeonLightsTestApp/ViewModels/NeonViewModel.swift
@@ -58,8 +58,7 @@ final class NeonViewModel: ObservableObject {
         // Parse async into an SVGLayer (SwiftSVG completion runs on main).
         // Store the root layer so it isn't deallocated before parsing finishes.
         let targetSize = CGSize(width: 512, height: 512)
-        svgRoot = CALayer(SVGData: data) { [weak self] svgLayer in
-            guard let self else { return }
+        svgRoot = CALayer(SVGData: data) { svgLayer in
             print("🔍 SVG parsed, resizing...")
             // Outline-only; scale to a convenient pixel space for our pipeline
             svgLayer.fillColor = UIColor.clear.cgColor


### PR DESCRIPTION
## Summary
- ensure SVG parsing callback captures `self` strongly so renderer always receives mesh

## Testing
- `swift test` *(fails: Could not find Package.swift in this directory or any of its parent directories.)*

------
https://chatgpt.com/codex/tasks/task_e_68bee3d4d6088323a71affe48cdf67ff