### PR TITLE
Ensure renderer resizes buffers during SwiftUI layout updates

### DIFF
--- a/NeonLightsTestApp/ViewModels/NeonView.swift
+++ b/NeonLightsTestApp/ViewModels/NeonView.swift
@@ -36,6 +36,12 @@ public struct NeonView: UIViewRepresentable {
         let size = CGSize(width: uiView.bounds.width * scale,
                           height: uiView.bounds.height * scale)
         uiView.drawableSize = size
+        // Explicitly notify the renderer about the new drawable size so it can
+        // allocate or resize its internal buffers immediately. Relying on
+        // MTKView's delegate callback can be racy when the size changes during
+        // SwiftUI layout updates, leading to a black screen if the renderer
+        // hasn't yet provisioned its textures.
+        renderer.mtkView(uiView, drawableSizeWillChange: size)
         print("📐 updateUIView -> drawableSize: \(size)")
     }
 }


### PR DESCRIPTION
## Summary
- Notify `NeonRenderer` when `MTKView` drawable size changes in `NeonView` to guarantee offscreen textures match SwiftUI layout

## Testing
- `swift build` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_68bee550c0fc83238dacfeb2c3248eb9